### PR TITLE
Drop static actions usage in favor of more OO approach

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 
 # NetBeans project folder
 nbproject
+.idea
 
 *.swp
 *.un~

--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -151,9 +151,14 @@ class EpiRoute
 
     if (empty($routeDef))
       error_log('callback does not exist for path:' . $route . ' method: ' . $httpMethod);
-  
-    $handler = call_user_func([$routeDef['callback'][0], 'getInstance']); // i() is not a good name
-    $response = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
+
+    if (method_exists($routeDef['callback'][0], 'getInstance')) {
+      $handler = call_user_func([$routeDef['callback'][0], 'getInstance']);
+      $response = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
+    }
+    else {
+      $response = call_user_func_array($routeDef['callback'], $routeDef['args']);
+    }
 
     if(!$routeDef['postprocess'])
       return $response;
@@ -233,8 +238,13 @@ class EpiRoute
     }
     
     $GLOBALS["invoked"] = true;
-    $handler = call_user_func([$routeDef['callback'][0], 'getInstance']);
-    $retval = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
+    if (method_exists($routeDef['callback'][0], 'getInstance')) {
+      $handler = call_user_func([$routeDef['callback'][0], 'getInstance']);
+      $retval = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
+    }
+    else {
+      $retval = call_user_func_array($routeDef['callback'], $routeDef['args']);
+    }
     
     // restore sanity
     foreach($tmps as $type => $value)

--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -151,8 +151,10 @@ class EpiRoute
 
     if (empty($routeDef))
       error_log('callback does not exist for path:' . $route . ' method: ' . $httpMethod);
-    
-    $response = call_user_func_array($routeDef['callback'], $routeDef['args']);
+  
+    $handler = call_user_func([$routeDef['callback'][0], 'getInstance']); // i() is not a good name
+    $response = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
+
     if(!$routeDef['postprocess'])
       return $response;
     else

--- a/src/EpiRoute.php
+++ b/src/EpiRoute.php
@@ -233,7 +233,8 @@ class EpiRoute
     }
     
     $GLOBALS["invoked"] = true;
-    $retval = call_user_func_array($routeDef['callback'], $routeDef['args']);
+    $handler = call_user_func([$routeDef['callback'][0], 'getInstance']);
+    $retval = call_user_func_array([$handler, $routeDef['callback'][1]], $routeDef['args']);
     
     // restore sanity
     foreach($tmps as $type => $value)


### PR DESCRIPTION
1. Why is this change necessary?

As of now we're forced to use static actions to handle requests. Due to
that have lots of static methods, which make our code less testable.

Furthermore the way we have the code, we're already using singletons
by acknowleding that fact into the frameworks code, we're able to clean
our controllers from static methods.

Now we can have code like:

```php
class SiteController {

    protected static $instance;
    
    public static function getInstance() {
        return static::$instance;
    }

    public static function setInstance($instance) {
        static::$instance = $instance;
    }

    public function construct() {}

    public function homeAction() {
        echo 'home';
    }

    public function aboutAction() {
        echo 'about our lovely site';
    }
}

$siteController = new SiteController(); // allows us to pass dependencies directly in constructor without needing other stuff. And makes class instantiable for unit tests
SiteController::setInstance($siteController); // singletons that enforce their own singleton-ness are problematic. And as seen in WELC having a setter for the singleton instance is a strategy for testing.

// we initialize the routing stuff after we've initialized our objects in our composition root (boot.php)
Epi::init('route');
getRoute()->get('/', ['SiteController', 'homeAction']);
getRoute()->get('/home', ['SiteController', 'homeAction']);
getRoute()->get('/about', ['SiteController', 'aboutAction']);
getRoute()->run(); 
```

3. What are the side effects

We can't have simple functions as request handlers. All request handlers must be inside classes.